### PR TITLE
Pin NETStandard.Library to 1.6.0

### DIFF
--- a/src/JsonNetConverters/JsonNetConverters.csproj
+++ b/src/JsonNetConverters/JsonNetConverters.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>    
     <PackageId>UnixTimeConverter</PackageId>
     <PackageVersion>1.2.0</PackageVersion>
     <Authors>Egor Grishechko</Authors>


### PR DESCRIPTION
I'm trying to use this library in AWS Lambda, which can only run .NET Core 1.0. .NET Core 1.0 can only use [NETStandard.Library 1.6.0](https://www.nuget.org/packages/NETStandard.Library/1.6.0). I believe the netstandard1.3 now defaults to target 1.6.1.

This PR pins the 1.0 compatible version.